### PR TITLE
Included GIFs into Custom & Generated Workout screens

### DIFF
--- a/Fortis/src/screens/workout/WorkoutGenerationScreen.js
+++ b/Fortis/src/screens/workout/WorkoutGenerationScreen.js
@@ -9,6 +9,9 @@ import {
   StyleSheet,
   SafeAreaView,
   TouchableOpacity,
+  Image,
+  Modal,
+  Dimensions,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useApp } from '../../context/AppContext';
@@ -19,6 +22,8 @@ import { typography } from '../../utils/typography';
 import { spacing } from '../../utils/spacing';
 import Card from '../../components/common/Card';
 import { generateWorkout } from '../../utils/generateWorkout';
+
+const { width: screenWidth } = Dimensions.get('window');
 
 const toTitleCase = (str) => {
   const lowerWords = ['of', 'on', 'in', 'at', 'to', 'for', 'with', 'a', 'an', 'the', 'and', 'but', 'or'];
@@ -86,6 +91,11 @@ const WorkoutGenerationScreen = ({ route, navigation }) => {
     estimatedTime: 0,
     totalVolume: 0,
   });
+  
+  // State management for GIF demonstration functionality
+  const [expandedExercises, setExpandedExercises] = useState(new Set());
+  const [selectedGif, setSelectedGif] = useState(null);
+  const [showGifModal, setShowGifModal] = useState(false);
 
   useEffect(() => {
     fetchExercises();
@@ -99,9 +109,10 @@ const WorkoutGenerationScreen = ({ route, navigation }) => {
 
   const fetchExercises = async () => {
     try {
+      // Include gif_url in query to enable exercise demonstrations
       const { data, error } = await supabase
         .from('exercises')
-        .select('*')
+        .select('*, gif_url')
         .in('equipment', ['body weight', 'barbell', 'dumbbell', 'cable', 'machine'])
         .limit(500);
 
@@ -177,51 +188,105 @@ const WorkoutGenerationScreen = ({ route, navigation }) => {
     });
   };
 
-  const renderWorkout = ({ item, index }) => (
-  <Card style={[
-    styles.exerciseCard,
-    index === 0 && styles.firstExerciseCard
-  ]}>
-    <View style={styles.exerciseHeader}>
-      {/* Removed the number section entirely */}
-      <View style={styles.exerciseInfo}>
-        <Text style={styles.exerciseName}>{toTitleCase(item.name)}</Text>
-        <View style={styles.exerciseMetrics}>
-          <View style={styles.metricItem}>
-            <Ionicons name="fitness" size={18} color={colors.primary} />
-            <Text style={styles.metricText}>{item.sets} × {item.reps}</Text>
-          </View>
-          {item.weight && (
-            <View style={styles.metricItem}>
-              <Ionicons name="barbell" size={18} color={colors.secondary} />
-              <Text style={styles.metricText}>{item.weight} lbs</Text>
+  // Toggle exercise demonstration visibility for individual exercises
+  const toggleExerciseDemo = (exerciseId) => {
+    const newExpanded = new Set(expandedExercises);
+    if (newExpanded.has(exerciseId)) {
+      newExpanded.delete(exerciseId);
+    } else {
+      newExpanded.add(exerciseId);
+    }
+    setExpandedExercises(newExpanded);
+  };
+
+  // Display exercise GIF in full-screen modal
+  const openGifModal = (gifUrl, exerciseName) => {
+    setSelectedGif({ url: gifUrl, name: exerciseName });
+    setShowGifModal(true);
+  };
+
+  const renderWorkout = ({ item, index }) => {
+    const isExpanded = expandedExercises.has(item.id);
+    
+    return (
+      <Card style={[
+        styles.exerciseCard,
+        index === 0 && styles.firstExerciseCard
+      ]}>
+        <View style={styles.exerciseHeader}>
+          <View style={styles.exerciseInfo}>
+            <View style={styles.exerciseNameRow}>
+              <Text style={styles.exerciseName}>{toTitleCase(item.name)}</Text>
+              {/* Demo button appears only for exercises with available GIFs */}
+              {item.gif_url && (
+                <TouchableOpacity 
+                  onPress={() => toggleExerciseDemo(item.id)}
+                  style={[styles.demoButton, isExpanded && styles.demoButtonActive]}
+                >
+                  <Ionicons 
+                    name={isExpanded ? "eye-off" : "eye"} 
+                    size={16} 
+                    color={isExpanded ? '#FFFFFF' : colors.textSecondary} 
+                  />
+                  <Text style={[styles.demoButtonText, isExpanded && styles.demoButtonTextActive]}>
+                    {isExpanded ? 'Hide' : 'Demo'}
+                  </Text>
+                </TouchableOpacity>
+              )}
             </View>
-          )}
-          <View style={styles.metricItem}>
-            <Ionicons name="timer" size={18} color={colors.warning} />
-            <Text style={styles.metricText}>
-              {Math.floor(item.restTime / 60)}:{(item.restTime % 60).toString().padStart(2, '0')} rest
-            </Text>
+
+            <View style={styles.exerciseMetrics}>
+              <View style={styles.metricItem}>
+                <Ionicons name="fitness" size={18} color={colors.primary} />
+                <Text style={styles.metricText}>{item.sets} × {item.reps}</Text>
+              </View>
+              {item.weight && (
+                <View style={styles.metricItem}>
+                  <Ionicons name="barbell" size={18} color={colors.secondary} />
+                  <Text style={styles.metricText}>{item.weight} lbs</Text>
+                </View>
+              )}
+              <View style={styles.metricItem}>
+                <Ionicons name="timer" size={18} color={colors.warning} />
+                <Text style={styles.metricText}>
+                  {Math.floor(item.restTime / 60)}:{(item.restTime % 60).toString().padStart(2, '0')} rest
+                </Text>
+              </View>
+            </View>
+
+            {/* Collapsible exercise demonstration section */}
+            {isExpanded && item.gif_url && (
+              <View style={styles.demoSection}>
+                <TouchableOpacity 
+                  onPress={() => openGifModal(item.gif_url, item.name)}
+                  style={styles.gifContainer}
+                >
+                  <Image
+                    source={{ uri: item.gif_url }}
+                    style={styles.exerciseGif}
+                    resizeMode="contain"
+                  />
+                  <View style={styles.gifOverlay}>
+                    <Ionicons name="expand" size={16} color="#FFFFFF" />
+                    <Text style={styles.gifOverlayText}>Tap for full screen</Text>
+                  </View>
+                </TouchableOpacity>
+              </View>
+            )}
+
+            <View style={styles.exerciseTags}>
+              <View style={styles.tag}>
+                <Text style={styles.tagText}>{item.target}</Text>
+              </View>
+              <View style={styles.tag}>
+                <Text style={styles.tagText}>{item.equipment}</Text>
+              </View>
+            </View>
           </View>
         </View>
-        <View style={styles.exerciseTags}>
-          <View style={styles.tag}>
-            <Text style={styles.tagText}>{item.target}</Text>
-          </View>
-          <View style={styles.tag}>
-            <Text style={styles.tagText}>{item.equipment}</Text>
-          </View>
-        </View>
-      </View>
-      {/* <TouchableOpacity 
-        onPress={() => handleModifyExercise(index)}
-        style={styles.modifyButton}
-      >
-        <Ionicons name="create-outline" size={22} color={colors.textSecondary} />
-      </TouchableOpacity> */}
-    </View>
-  </Card>
-);
+      </Card>
+    );
+  };
 
   const handleStartWorkout = () => {
     navigation.navigate('WorkoutDisplay', {
@@ -238,6 +303,8 @@ const WorkoutGenerationScreen = ({ route, navigation }) => {
     }
     return `${mins}m`;
   };
+
+  const exercisesWithGifs = generatedWorkout.filter(ex => ex.gif_url).length;
 
   return (
     <SafeAreaView style={styles.container}>
@@ -293,8 +360,8 @@ const WorkoutGenerationScreen = ({ route, navigation }) => {
                       <Text style={styles.featureText}>Adjustable reps</Text>
                     </View>
                     <View style={styles.featureItem}>
-                      <Ionicons name="analytics" size={16} color={colors.success} />
-                      <Text style={styles.featureText}>Intensity feedback</Text>
+                      <Ionicons name="play-circle" size={16} color={colors.success} />
+                      <Text style={styles.featureText}>{exercisesWithGifs} video demos</Text>
                     </View>
                   </View>
                 </View>
@@ -330,6 +397,16 @@ const WorkoutGenerationScreen = ({ route, navigation }) => {
                     </View>
                   )}
                 </View>
+                
+                {/* Prompt users to preview exercise form before starting workout */}
+                {exercisesWithGifs > 0 && (
+                  <View style={styles.demoPrompt}>
+                    <Ionicons name="bulb" size={16} color={colors.warning} />
+                    <Text style={styles.demoPromptText}>
+                      Tap the "Demo" button on exercises to preview proper form before starting
+                    </Text>
+                  </View>
+                )}
               </Card>
 
               <View style={styles.sectionDivider} />
@@ -361,6 +438,42 @@ const WorkoutGenerationScreen = ({ route, navigation }) => {
           showsVerticalScrollIndicator={false}
         />
       )}
+
+      {/* Full-screen modal for detailed exercise form viewing */}
+      <Modal
+        visible={showGifModal}
+        transparent={true}
+        animationType="fade"
+        onRequestClose={() => setShowGifModal(false)}
+      >
+        <View style={styles.modalBackground}>
+          <View style={styles.modalContainer}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>
+                {selectedGif ? toTitleCase(selectedGif.name) : ''}
+              </Text>
+              <TouchableOpacity 
+                onPress={() => setShowGifModal(false)}
+                style={styles.modalCloseButton}
+              >
+                <Ionicons name="close" size={24} color="#FFFFFF" />
+              </TouchableOpacity>
+            </View>
+            {selectedGif && (
+              <Image
+                source={{ uri: selectedGif.url }}
+                style={styles.modalGif}
+                resizeMode="contain"
+              />
+            )}
+            <View style={styles.modalFooter}>
+              <Text style={styles.modalFooterText}>
+                Study the form, then close when ready to start your workout
+              </Text>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </SafeAreaView>
   );
 };
@@ -432,6 +545,21 @@ const styles = StyleSheet.create({
     color: colors.textSecondary,
     textAlign: 'center',
   },
+  demoPrompt: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    padding: spacing.md,
+    borderRadius: spacing.sm,
+    marginTop: spacing.md,
+  },
+  demoPromptText: {
+    ...typography.bodySmall,
+    color: colors.textSecondary,
+    marginLeft: spacing.sm,
+    flex: 1,
+    fontStyle: 'italic',
+  },
   aboutCard: {
     backgroundColor: colors.surfaceSecondary,
     marginBottom: spacing.sm,
@@ -476,7 +604,7 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     marginBottom: spacing.sm,
   },
-    featuresGrid: {
+  featuresGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'space-between',
@@ -494,8 +622,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   firstExerciseCard: {
-  marginTop: spacing.sm, // Small gap from divider for first card only
-},
+    marginTop: spacing.sm,
+  },
   exerciseCard: {
     backgroundColor: colors.surfaceSecondary,
     marginBottom: spacing.md,
@@ -506,21 +634,78 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     padding: spacing.xs,
   },
-  exerciseNumberText: {
-    ...typography.h2,
-    color: colors.primary,
-    fontSize: 20,
-    fontWeight: '600',
-  },
   exerciseInfo: {
     flex: 1,
+  },
+  exerciseNameRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.md,
   },
   exerciseName: {
     ...typography.h3,
     color: colors.textPrimary,
-    marginBottom: spacing.md,
     fontSize: 20,
     fontWeight: '500',
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  demoButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#2A2A2A',
+    borderRadius: 16,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderWidth: 1,
+    borderColor: '#444444',
+  },
+  demoButtonActive: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  demoButtonText: {
+    color: colors.textSecondary,
+    fontSize: 12,
+    fontWeight: 'bold',
+    marginLeft: 4,
+  },
+  demoButtonTextActive: {
+    color: '#FFFFFF',
+  },
+  demoSection: {
+    marginBottom: spacing.md,
+    backgroundColor: '#1A1A1A',
+    borderRadius: 12,
+    padding: spacing.md,
+  },
+  gifContainer: {
+    position: 'relative',
+    alignItems: 'center',
+  },
+  exerciseGif: {
+    width: screenWidth - 120,
+    height: 180,
+    borderRadius: 8,
+  },
+  gifOverlay: {
+    position: 'absolute',
+    bottom: 8,
+    left: 8,
+    right: 8,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    padding: 8,
+    borderRadius: 6,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  gifOverlayText: {
+    color: '#FFFFFF',
+    fontSize: 12,
+    marginLeft: 4,
+    fontStyle: 'italic',
   },
   exerciseMetrics: {
     flexDirection: 'row',
@@ -556,9 +741,6 @@ const styles = StyleSheet.create({
     fontSize: 10,
     textTransform: 'uppercase',
   },
-  modifyButton: {
-    padding: spacing.sm,
-  },
   buttonContainer: {
     paddingHorizontal: spacing.xl,
     marginTop: spacing.sm,
@@ -580,6 +762,56 @@ const styles = StyleSheet.create({
     ...typography.bodyMedium,
     color: colors.primary,
     marginLeft: spacing.sm,
+  },
+  modalBackground: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.9)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContainer: {
+    width: screenWidth - 40,
+    backgroundColor: '#1A1A1A',
+    borderRadius: 16,
+    padding: spacing.lg,
+    maxHeight: '80%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  modalTitle: {
+    ...typography.h2,
+    color: colors.textPrimary,
+    flex: 1,
+    fontSize: 18,
+  },
+  modalCloseButton: {
+    backgroundColor: '#FF4444',
+    borderRadius: 20,
+    width: 40,
+    height: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalGif: {
+    width: '100%',
+    height: 300,
+    borderRadius: 12,
+  },
+  modalFooter: {
+    marginTop: spacing.md,
+    paddingTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.surface,
+  },
+  modalFooterText: {
+    ...typography.bodySmall,
+    color: colors.textSecondary,
+    textAlign: 'center',
+    fontStyle: 'italic',
   },
 });
 

--- a/Fortis/src/utils/generateWorkout.js
+++ b/Fortis/src/utils/generateWorkout.js
@@ -239,6 +239,7 @@ export function generateWorkout({ allExercises, equipment, muscleGroup, fitnessL
       equipment: exercise.equipment,
       target: exercise.target,
       body_part: exercise.body_part,
+      gif_url: exercise.gif_url,
     };
   });
 


### PR DESCRIPTION
The GIFs are stored in Supabase Storage now, and those URLs replaced the busted ones that were getting pulled from ExerciseDB. This way, they won’t expire. For custom searches, the GIF shows up there, and when someone selects an exercise, it turns into a button they can tap to preview the demo. Same thing for generated workouts: once the workout is listed, there’s a button to view the preview, and when they actually start the workout and go through their sets, they can tap the form button to make sure they’re doing it right. I’m not sure if you want to include descriptions or instructions too, but for now I think just having the GIFs works fine.